### PR TITLE
✨ feat: align recoil state of selected git namespace and repository

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
   "rules": {
     "no-unused-vars": "warn",
     "no-console": "off",
+    "no-underscore-dangle": "off",
     "func-names": "off",
     "react/style-prop-object": "warn",
     "react/jsx-props-no-spreading": "off",
@@ -52,6 +53,7 @@
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/no-misused-promises": "warn",
     "@typescript-eslint/no-use-before-define": [
       "error",
       {

--- a/components/ButtonCreate.tsx
+++ b/components/ButtonCreate.tsx
@@ -1,12 +1,32 @@
+import { useRecoilValue, useSetRecoilState } from "recoil";
+
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 
+import { setCookie } from "cookies-next";
+import { getOrgs } from "../lib/api";
 import useModal from "../lib/hooks/useModal";
 
+import loginState from "../lib/recoil/auth";
+import gitNamespaceState from "../lib/recoil/git/namespace";
+
+import { GitNamespace, LoginData } from "../types";
+
 function ButtonCreate() {
+  const { data } =
+    useRecoilValue<LoginData | null>(loginState) || ({} as LoginData);
+  const setGitNamespaceState =
+    useSetRecoilState<GitNamespace[]>(gitNamespaceState);
   const { showModal } = useModal();
 
-  const handleClickModalCreate = () => {
+  const userId = data._id;
+
+  const handleClickModalCreate = async () => {
+    const { data: userOrgs } = await getOrgs(userId);
+
+    setCookie("userOrgs", JSON.stringify(userOrgs));
+    setGitNamespaceState(userOrgs);
+
     showModal({
       modalType: "ModalCreate",
     });

--- a/components/ModalCreate.tsx
+++ b/components/ModalCreate.tsx
@@ -15,6 +15,8 @@ import useModal from "../lib/hooks/useModal";
 import loginState from "../lib/recoil/auth";
 import { gitNamespaceList } from "../lib/recoil/git/namespace";
 import gitRepoState from "../lib/recoil/git/repos";
+import cloneUrlState from "../lib/recoil/git/clone";
+
 import { LoginData, GitNamespace, Repo } from "../types";
 
 function ModalCreate() {
@@ -22,6 +24,8 @@ function ModalCreate() {
     useRecoilValue<LoginData | null>(loginState) || ({} as LoginData);
   const gitNamespaces = useRecoilValue<GitNamespace[]>(gitNamespaceList);
   const [gitRepos, setGitRepos] = useRecoilState<Repo[]>(gitRepoState);
+  const setCloneUrl = useSetRecoilState<string>(cloneUrlState);
+
   const [spaces, setSpaces] = useState<string>("");
   const [repository, setRepository] = useState<string>("");
   const { showModal } = useModal();
@@ -60,8 +64,12 @@ function ModalCreate() {
 
     return setGitRepos(userRepos);
   };
-  const handleSecondChange = (event: SelectChangeEvent) => {
-    setRepository(event.target.value);
+
+  const handleRepoChange = (e: SelectChangeEvent) => {
+    const selectedRepoUrl = e.target.value;
+    setRepository(selectedRepoUrl);
+
+    setCloneUrl(selectedRepoUrl);
   };
 
   return (

--- a/components/ModalCreate.tsx
+++ b/components/ModalCreate.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -10,10 +11,13 @@ import Typography from "@mui/material/Typography";
 
 import useModal from "../lib/hooks/useModal";
 
+import { gitNamespaceList } from "../lib/recoil/git/namespace";
+import { LoginData, GitNamespace, Repo } from "../types";
 function ModalCreate() {
-  const { showModal } = useModal();
+  const gitNamespaces = useRecoilValue<GitNamespace[]>(gitNamespaceList);
   const [spaces, setSpaces] = useState<string>("");
   const [repository, setRepository] = useState<string>("");
+  const { showModal } = useModal();
 
   const isButtonNext = () => {
     return spaces !== "" && repository !== "";
@@ -70,25 +74,25 @@ function ModalCreate() {
           <Box sx={{ width: "90%", marginTop: 1.5 }}>
             <FormControl size="small" fullWidth>
               <InputLabel id="select-label" sx={{ fontSize: "small" }}>
-                Spaces
+                Select a Git Namespace
               </InputLabel>
               <Select
                 labelId="select-label"
                 id="select"
                 value={spaces}
-                label="spaces"
+                label="Select a Git Namespace"
                 sx={{ fontSize: "small" }}
-                onChange={handleChange}
+                onChange={handleSpaceChange}
               >
-                <MenuItem value={0} sx={{ fontSize: "small" }}>
-                  Room-Planet
-                </MenuItem>
-                <MenuItem value={1} sx={{ fontSize: "small" }}>
-                  Bumper-Dosi
-                </MenuItem>
-                <MenuItem value={2} sx={{ fontSize: "small" }}>
-                  Design-Pattern
-                </MenuItem>
+                {gitNamespaces.map(space => (
+                  <MenuItem
+                    key={`${space.spaceName}`}
+                    value={space.spaceUrl}
+                    sx={{ fontSize: "small" }}
+                  >
+                    {space.spaceName}
+                  </MenuItem>
+                ))}
               </Select>
             </FormControl>
           </Box>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,12 +14,15 @@ import Tooltip from "@mui/material/Tooltip";
 
 import loginState from "../lib/recoil/auth";
 
+import { LoginData } from "../types";
+
 function NavBar() {
-  const setIsLoggedIn = useSetRecoilState(loginState);
+  const setIsLoggedIn = useSetRecoilState<LoginData | null>(loginState);
   const router = useRouter();
 
   const handleLogout = () => {
     removeCookies("loginData");
+    removeCookies("userOrgs");
     setIsLoggedIn(null);
 
     router.push("/login");

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -3,12 +3,7 @@ import { getCookie } from "cookies-next";
 
 import Config from "../config";
 
-import {
-  GetOrgsResponse,
-  GetRepoReponse,
-  GetReposResponse,
-  LoginResponse,
-} from "../../types";
+import { GetOrgsResponse, GetReposResponse, LoginResponse } from "../../types";
 
 const MainClient: AxiosInstance = axios.create({
   baseURL: Config.SERVER_URL,
@@ -57,15 +52,17 @@ export const getOrgs = async (userId: string) => {
   return data;
 };
 
-export const getOrgs = async () => {
-  const { data } = await MainClient.get<GetOrgsResponse>("/user/orgs");
+export const getUserRepos = async (userId: string) => {
+  const { data } = await MainClient.get<GetReposResponse>(
+    `/users/${userId}/repos`,
+  );
 
   return data;
 };
 
-export const getOrgRepos = async (org: string) => {
+export const getOrgRepos = async (userId: string, org: string) => {
   const { data } = await MainClient.get<GetReposResponse>(
-    `/user/orgs/${org}/repos`,
+    `/users/${userId}/orgs/${org}/repos`,
   );
 
   return data;

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -22,6 +22,11 @@ MainClient.interceptors.request.use((req: AxiosRequestConfig) => {
         JSON.parse(getCookie("loginData") as string).accessToken as string
       }`,
     };
+
+    req.params = {
+      githubAccessToken: JSON.parse(getCookie("loginData") as string)
+        .githubAccessToken as string,
+    };
   }
 
   return req;

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -68,8 +68,10 @@ export const getOrgRepos = async (userId: string, org: string) => {
   return data;
 };
 
-export const getRepo = async (repo: string) => {
-  const { data } = await MainClient.get<GetRepoReponse>(`user/repos/${repo}`);
+export const deployRepo = async (userId: string, cloneUrl: string) => {
+  const { data } = await MainClient.post<GetReposResponse>(`/users/${userId}`, {
+    cloneUrl,
+  });
 
   return data;
 };

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -49,8 +49,10 @@ export const login = async (code: string) => {
   return data;
 };
 
-export const getRepos = async () => {
-  const { data } = await MainClient.get<GetReposResponse>("/user/repos");
+export const getOrgs = async (userId: string) => {
+  const { data } = await MainClient.get<GetOrgsResponse>(
+    `/users/${userId}/orgs`,
+  );
 
   return data;
 };

--- a/lib/hooks/useModal.ts
+++ b/lib/hooks/useModal.ts
@@ -4,8 +4,8 @@ import { modalState, ModalType } from "../recoil/modal";
 function useModal() {
   const [isModal, setIsModal] = useRecoilState(modalState);
 
-  const showModal = ({ modalType }: ModalType) => {
-    setIsModal({ modalType });
+  const showModal = (modalTypeObj: ModalType) => {
+    setIsModal(modalTypeObj);
   };
 
   const hideModal = () => {

--- a/lib/recoil/auth/atom.ts
+++ b/lib/recoil/auth/atom.ts
@@ -1,12 +1,7 @@
 import { atom } from "recoil";
 import { getCookie } from "cookies-next";
 
-import { UserLoginData } from "../../../types";
-
-type LoginData = {
-  data: UserLoginData;
-  accessToken: string;
-};
+import { LoginData } from "../../../types";
 
 const loginState = atom<LoginData | null>({
   key: "loginState",

--- a/lib/recoil/git/clone/atom.ts
+++ b/lib/recoil/git/clone/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const cloneUrlState = atom({
+  key: "cloneUrlState",
+  default: "",
+});
+
+export default cloneUrlState;

--- a/lib/recoil/git/clone/index.ts
+++ b/lib/recoil/git/clone/index.ts
@@ -1,0 +1,3 @@
+import cloneUrlState from "./atom";
+
+export default cloneUrlState;

--- a/lib/recoil/git/namespace/atom.ts
+++ b/lib/recoil/git/namespace/atom.ts
@@ -1,0 +1,10 @@
+import { atom } from "recoil";
+
+import { GitNamespace } from "../../../../types";
+
+const gitNamespaceState = atom<GitNamespace[]>({
+  key: "gitNamespaceState",
+  default: [],
+});
+
+export default gitNamespaceState;

--- a/lib/recoil/git/namespace/index.ts
+++ b/lib/recoil/git/namespace/index.ts
@@ -1,0 +1,6 @@
+import gitNamespaceState from "./atom";
+import gitNamespaceList from "./namespaceSelector";
+
+export { gitNamespaceList };
+
+export default gitNamespaceState;

--- a/lib/recoil/git/namespace/namespaceSelector.ts
+++ b/lib/recoil/git/namespace/namespaceSelector.ts
@@ -1,0 +1,32 @@
+import { selector } from "recoil";
+import { getCookie } from "cookies-next";
+
+import gitNamespaceAtom from "./atom";
+
+import { GitNamespace, UserLoginData, LoginResponse } from "../../../../types";
+
+const gitNamespaceList = selector<GitNamespace[]>({
+  key: "gitNamespaceList",
+  get: ({ get }) => {
+    const orgsSpaceList = get(gitNamespaceAtom);
+
+    const userSpace: GitNamespace = {
+      spaceName: "",
+      spaceUrl: "",
+    };
+
+    if (getCookie("loginData")) {
+      const { data: loggedInUserData }: { data: UserLoginData } = JSON.parse(
+        getCookie("loginData") as string,
+      ) as LoginResponse;
+
+      userSpace.spaceName = loggedInUserData.username;
+      userSpace.spaceUrl = loggedInUserData.userGithubUri;
+      userSpace.spaceImage = loggedInUserData.userImage;
+    }
+
+    return [userSpace, ...orgsSpaceList];
+  },
+});
+
+export default gitNamespaceList;

--- a/lib/recoil/git/repos/atom.ts
+++ b/lib/recoil/git/repos/atom.ts
@@ -1,0 +1,10 @@
+import { atom } from "recoil";
+
+import { Repo } from "../../../../types";
+
+const gitRepoState = atom<Repo[]>({
+  key: "gitRepoState",
+  default: [],
+});
+
+export default gitRepoState;

--- a/lib/recoil/git/repos/index.ts
+++ b/lib/recoil/git/repos/index.ts
@@ -1,0 +1,3 @@
+import gitRepoState from "./atom";
+
+export default gitRepoState;

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -10,24 +10,24 @@ import NavBar from "../components/Navbar";
 import SearchInput from "../components/SearchInput";
 
 import Login from "./login";
-import loginState from "../lib/recoil/auth";
+import { isLoggedInState } from "../lib/recoil/auth";
 
 function Dashboard() {
-  const isLoggedIn = useRecoilValue(loginState);
+  const isLoggedIn = useRecoilValue(isLoggedInState);
   const router = useRouter();
-  const [isRendered, setIsRendered] = useState(false);
+  const [isSSR, setIsSSR] = useState(true);
 
   useEffect(() => {
     if (!isLoggedIn) {
       router.replace("/login");
     }
 
-    setIsRendered(true);
+    setIsSSR(false);
   }, [isLoggedIn, router]);
 
   return (
     <Container>
-      {isRendered && isLoggedIn ? (
+      {!isSSR && isLoggedIn ? (
         <>
           <NavBar />
           <Container maxWidth="lg">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,24 +7,24 @@ import Container from "@mui/material/Container";
 import ButtonLogin from "../components/ButtonLogin";
 
 import Dashboard from "./dashboard";
-import loginState from "../lib/recoil/auth";
+import { isLoggedInState } from "../lib/recoil/auth";
 
 function PageLanding() {
-  const isLoggedIn = useRecoilValue(loginState);
+  const isLoggedIn = useRecoilValue(isLoggedInState);
   const router = useRouter();
-  const [isRendered, setIsRendered] = useState(false);
+  const [isSSR, setIsSSR] = useState(true);
 
   useEffect(() => {
     if (isLoggedIn) {
       router.replace("/dashboard");
     }
 
-    setIsRendered(true);
+    setIsSSR(false);
   }, [isLoggedIn, router]);
 
   return (
     <Container>
-      {isRendered && isLoggedIn ? (
+      {!isSSR && isLoggedIn ? (
         <Dashboard />
       ) : (
         <Container maxWidth="lg">

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -11,18 +11,23 @@ import loginState from "../lib/recoil/auth";
 
 import ButtonLogin from "../components/ButtonLogin";
 
+import { LoginData } from "../types";
+
 function Login() {
-  const setLoginState = useSetRecoilState(loginState);
+  const setLoginState = useSetRecoilState<LoginData | null>(loginState);
   const router = useRouter();
   const authCode = router.query.code;
 
   useEffect(() => {
     const handleLogin = async (code: string) => {
       try {
-        const { data, accessToken } = await login(code);
+        const { data, githubAccessToken, accessToken } = await login(code);
 
-        setLoginState({ data, accessToken });
-        setCookies("loginData", JSON.stringify({ data, accessToken }));
+        setLoginState({ data, githubAccessToken, accessToken });
+        setCookies(
+          "loginData",
+          JSON.stringify({ data, githubAccessToken, accessToken }),
+        );
 
         router.replace("/dashboard");
       } catch (error) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,28 +5,35 @@ export type UserLoginData = {
   userImage?: string;
 };
 
-export type LoginResponse = {
-  result: string;
+export type LoginData = {
   data: UserLoginData;
+  githubAccessToken: string;
   accessToken: string;
 };
 
-export type Repo = {};
-
-export type GetReposResponse = {
-  data: Repo[];
+export type LoginResponse = {
+  result: string;
+  data: UserLoginData;
+  githubAccessToken: string;
+  accessToken: string;
 };
 
-export type GetRepoReponse = {
-  data: Repo;
+export type GitNamespace = {
+  spaceName: string;
+  spaceUrl: string;
+  spaceImage?: string;
 };
-
-export type Org = {};
 
 export type GetOrgsResponse = {
-  data: Org[];
+  data: GitNamespace[];
 };
 
-export type GetOrgReposResponse = {
+export type Repo = {
+  repoName: string;
+  repoCloneUrl: string;
+  repoUpdatedAt: string;
+};
+
+export type GetReposResponse = {
   data: Repo[];
 };


### PR DESCRIPTION
## Task

- [프론트 repository 관련 api 및 상태관리](https://taewan.notion.site/repository-api-beb5094dda5f4a678574d30227b77a0e)

## Description

- `ButtonCreate.tsx` 클릭
  - `organization` 리스트 api 요청
- `ButtonCreate.tsx`
  - `git namespace` 한 개 선택 (`user` 또는 `organization` 리스트 중)
  - 선택한 `git namespace` 의 `repository` 선택
    - 선택한 `repository` api 요청

## Key Points

- git namespace 와 repository 를 선택하는 과정을 한 개의 모달에 넣은 상황이기 때문에 (많은 기능이 한 개의 모달에 들어간 상황)
   옵션을 select 할 때마다 Github api 요청을 하고 데이터를 받아서 상태를 저장하는 과정이 사용자 환경에 따라 경험이 느려질 수 있을 것 같음
- 추후에, `ButtonCreate.tsx` 버튼을 눌렀을 때, `git namespace` (`user`) 와 `user` 의 `repository` 들이 
   default 로 먼저 설정되어 있게 리팩토링 한다면 옵션을 선택하는 시간을 단축해서 좀 더 빠른 사용자 경험을 만들 수 있을 것 같습니다

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- 
