### PR TITLE
✨ feat: set RepoDeployOptions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "off",
     "react/prop-types": "off",
+    "react/no-array-index-key": "warn",
     "jsx-a11y/alt-text": [
       "warn",
       {

--- a/components/ModalBuild.tsx
+++ b/components/ModalBuild.tsx
@@ -39,7 +39,24 @@ function ModalBuild() {
     });
   };
 
-  const handleClickModalDeploy = () => {
+  const handleClickModalDeploy = async () => {
+    const filteredEnvs = envs.filter((_, i) => i !== 0);
+
+    const userBuildOptions = {
+      userId,
+      repoName,
+      repoCloneUrl,
+      repoUpdatedAt: "",
+      nodeVersion: version,
+      installCommand: install,
+      buildCommand: build,
+      envList: filteredEnvs,
+    };
+
+    const deployData = await deployRepo(userBuildOptions);
+
+    console.info("deployData", deployData);
+
     showModal({
       modalType: "ModalDeploy",
     });

--- a/components/TextFieldSaved.tsx
+++ b/components/TextFieldSaved.tsx
@@ -1,43 +1,16 @@
-import { ChangeEvent, useState } from "react";
-
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import TextField from "@mui/material/TextField";
-import AddIcon from "@mui/icons-material/Add";
 import IconButton from "@mui/material/IconButton";
+import RemoveIcon from "@mui/icons-material/Remove";
 
 import { EnvsState } from "../types";
 
-function TextFieldAdd({ envsState }: EnvsState) {
+function TextFieldSaved({ envIndex, envsState }: EnvsState) {
   const { envs, setEnvs } = envsState;
-  const [curEnvKey, setCurEnvKey] = useState<string>("");
-  const [curEnvValue, setCurEnvValue] = useState<string>("");
 
-  const handleKeyChange = (
-    e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
-  ) => {
-    const targetKey = e.target.value;
-
-    setCurEnvKey(targetKey.trim());
-  };
-
-  const handleValueChange = (
-    e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
-  ) => {
-    const targetValue = e.target.value;
-
-    setCurEnvValue(targetValue.trim());
-  };
-
-  const handleClickEnvAdd = () => {
-    const newEnv = {
-      key: curEnvKey,
-      value: curEnvValue,
-    };
-
-    setEnvs(prevEnvs => [...prevEnvs, newEnv]);
-    setCurEnvKey("");
-    setCurEnvValue("");
+  const handleClickEnvRemove = (curIndex: number) => {
+    setEnvs(prevEnvs => prevEnvs.filter((_, index) => index !== curIndex));
   };
 
   return (
@@ -52,9 +25,9 @@ function TextFieldAdd({ envsState }: EnvsState) {
             autoComplete="off"
             inputProps={{ sx: { fontSize: "small" } }}
             InputLabelProps={{ sx: { fontSize: "small" } }}
-            value={curEnvKey}
-            placeholder="EXAMPLE_KEY"
-            onChange={handleKeyChange}
+            style={{ color: "#333" }}
+            value={envs[envIndex].key}
+            disabled
           />
         </FormControl>
       </Box>
@@ -68,9 +41,9 @@ function TextFieldAdd({ envsState }: EnvsState) {
             autoComplete="off"
             inputProps={{ sx: { fontSize: "small" } }}
             InputLabelProps={{ sx: { fontSize: "small" } }}
-            value={curEnvValue}
-            placeholder="fd1c1c36245869e5c0bb0d"
-            onChange={handleValueChange}
+            style={{ color: "#333" }}
+            value={envs[envIndex].value}
+            disabled
           />
         </FormControl>
       </Box>
@@ -83,13 +56,12 @@ function TextFieldAdd({ envsState }: EnvsState) {
             color: "#000",
           },
         }}
-        onClick={handleClickEnvAdd}
-        disabled={!curEnvKey || !curEnvValue}
+        onClick={() => handleClickEnvRemove(envIndex)}
       >
-        <AddIcon />
+        <RemoveIcon />
       </IconButton>
     </Box>
   );
 }
 
-export default TextFieldAdd;
+export default TextFieldSaved;

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -3,7 +3,12 @@ import { getCookie } from "cookies-next";
 
 import Config from "../config";
 
-import { GetOrgsResponse, GetReposResponse, LoginResponse } from "../../types";
+import {
+  GetOrgsResponse,
+  GetReposResponse,
+  LoginResponse,
+  RepoDeployOptions,
+} from "../../types";
 
 const MainClient: AxiosInstance = axios.create({
   baseURL: Config.SERVER_URL,
@@ -68,10 +73,28 @@ export const getOrgRepos = async (userId: string, org: string) => {
   return data;
 };
 
-export const deployRepo = async (userId: string, cloneUrl: string) => {
-  const { data } = await MainClient.post<GetReposResponse>(`/users/${userId}`, {
-    cloneUrl,
-  });
+export const deployRepo = async (userBuildOptions: RepoDeployOptions) => {
+  const {
+    userId,
+    repoName,
+    repoCloneUrl,
+    nodeVersion,
+    installCommand,
+    buildCommand,
+    envList,
+  } = userBuildOptions;
+
+  const { data } = await MainClient.post<RepoDeployOptions>(
+    `/deploy/${userId}`,
+    {
+      repoName,
+      repoCloneUrl,
+      nodeVersion,
+      envList,
+      installCommand,
+      buildCommand,
+    },
+  );
 
   return data;
 };

--- a/lib/recoil/git/clone/index.ts
+++ b/lib/recoil/git/clone/index.ts
@@ -1,3 +1,6 @@
 import cloneUrlState from "./atom";
+import cloneRepoName from "./repoNameSelector";
+
+export { cloneRepoName };
 
 export default cloneUrlState;

--- a/lib/recoil/git/clone/repoNameSelector.ts
+++ b/lib/recoil/git/clone/repoNameSelector.ts
@@ -1,0 +1,21 @@
+import { selector } from "recoil";
+
+import cloneUrlState from "./atom";
+
+const cloneRepoName = selector<string>({
+  key: "cloneRepoName",
+  get: ({ get }) => {
+    const cloneUrl = get(cloneUrlState);
+
+    const repoName = cloneUrl
+      .split("https://github.com/")[1]
+      .split("/")[1]
+      .split(".git")[0]
+      .replace(/[^a-zA-Z0-9-]/g, "")
+      .toLowerCase();
+
+    return repoName;
+  },
+});
+
+export default cloneRepoName;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from "react";
+
 export type UserLoginData = {
   _id: string;
   username: string;
@@ -42,3 +44,22 @@ export type Env = {
   key: string;
   value: string;
 };
+
+export interface EnvsState {
+  envIndex: number;
+  envsState: {
+    envs: Env[];
+    setEnvs: Dispatch<SetStateAction<Env[]>>;
+  };
+}
+
+export interface DeploymentOptions {
+  nodeVersion: string;
+  installCommand?: string;
+  buildCommand?: string;
+  envList?: Env[];
+}
+
+export interface RepoDeployOptions extends Repo, DeploymentOptions {
+  userId: string;
+}


### PR DESCRIPTION
## Task

- [RepoDeployOptions](https://taewan.notion.site/RepoDeployOptions-ddb46b30466d459c8fc983d4485b1168)

## Description

- `RepoDeployOptions` 을 보낼 수 있는 프론트엔드 설정
  - `deployRepo` 요청 이후 응답을 받는 형태는 임시로 세팅
- 환경변수 상태 관리하는 부분이 없어서 기존에 있던 컴포넌트 활용해서 구현
  - UI 변경
    <img width="300" alt="image" src="https://user-images.githubusercontent.com/59520911/201004153-bacccfd0-2dac-438c-a01d-1c22639ba8fd.png">

## Key Points

- 추후에 배포에 필요한 옵션들 전역상태로 관리하면 사용자 경험이 더 좋아질 듯 함 (모달이 꺼졌다 켜져도 유지될 수 있도록)

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- 
