### PR TITLE
✨ feat: set up database logic for dashboard page

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -24,6 +24,7 @@ function NavBar() {
   const handleLogout = () => {
     removeCookies("loginData");
     removeCookies("userOrgs");
+    removeCookies("userDeployments");
     setIsLoggedIn(null);
 
     router.push("/login");

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -1,15 +1,13 @@
-/* eslint-disable react/no-array-index-key */
-import { useState } from "react";
-
 import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import ChangeHistoryIcon from "@mui/icons-material/ChangeHistory";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import Typography from "@mui/material/Typography";
 import CardActionArea from "@mui/material/CardActionArea";
 
-function RepoCard() {
+import { UserDeploymentData } from "../types";
+
+function RepoCard({ cardData }: { cardData: UserDeploymentData }) {
   return (
     <CardActionArea>
       <CardContent sx={{ padding: 0, margin: 2 }}>
@@ -17,20 +15,20 @@ function RepoCard() {
           <ChangeHistoryIcon fontSize="medium" />
           <Box display="flex" sx={{ flexDirection: "column", marginLeft: 1 }}>
             <Typography fontSize="large" fontWeight="bold">
-              repository-name
+              {cardData.repoName}
             </Typography>
-            <Typography fontSize="medium">site-url</Typography>
+            <Typography fontSize="medium">{cardData.deployedUrl}</Typography>
           </Box>
         </Box>
         <Typography fontSize="small" fontWeight="medium" sx={{ marginTop: 2 }}>
-          📝[docs] Update README
+          {cardData.lastCommitMessage}
         </Typography>
         <Box
           display="flex"
           sx={{ flexDirection: "row", marginTop: 2, alignItems: "center" }}
         >
           <Typography fontSize="small" fontWeight="medium">
-            22h ago via
+            {cardData.repoUpdatedAt} via
           </Typography>
           <GitHubIcon fontSize="small" sx={{ marginLeft: 0.5 }} />
         </Box>
@@ -39,28 +37,4 @@ function RepoCard() {
   );
 }
 
-function Content() {
-  const [cardList] = useState([]);
-
-  return (
-    <Box display="flex" sx={{ flexDirection: "row" }}>
-      {cardList.map((card, index) => {
-        return (
-          <Box
-            key={index}
-            sx={{
-              padding: 1,
-              margin: 1,
-            }}
-          >
-            <Card variant="elevation">
-              <RepoCard />
-            </Card>
-          </Box>
-        );
-      })}
-    </Box>
-  );
-}
-
-export default Content;
+export default RepoCard;

--- a/components/RepoCardList.tsx
+++ b/components/RepoCardList.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+
+import RepoCard from "./RepoCard";
+
+import { UserDeploymentData } from "../types";
+
+function RepoCardList({
+  userDeploymentsList,
+}: {
+  userDeploymentsList: UserDeploymentData[];
+}) {
+  const [cardDataList] = useState<UserDeploymentData[]>(userDeploymentsList);
+
+  return (
+    <Box display="flex" sx={{ flexDirection: "row" }}>
+      {cardDataList.map((cardData, index) => {
+        return (
+          <Box
+            key={index}
+            sx={{
+              padding: 1,
+              margin: 1,
+            }}
+          >
+            <Card variant="elevation">
+              <RepoCard cardData={cardData} />
+            </Card>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default RepoCardList;

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -4,6 +4,8 @@ import { getCookie } from "cookies-next";
 import Config from "../config";
 
 import {
+  DeploymentDataResponse,
+  DeploymentListResponse,
   GetOrgsResponse,
   GetReposResponse,
   LoginResponse,
@@ -75,22 +77,36 @@ export const deployRepo = async (userBuildOptions: RepoDeployOptions) => {
     userId,
     repoName,
     repoCloneUrl,
+    repoUpdatedAt,
     nodeVersion,
     installCommand,
     buildCommand,
     envList,
+    bulidType,
+    lastCommitMessage,
   } = userBuildOptions;
 
-  const { data } = await MainClient.post<RepoDeployOptions>(
+  const { data } = await MainClient.post<DeploymentDataResponse>(
     `/deploy/${userId}`,
     {
       repoName,
       repoCloneUrl,
+      repoUpdatedAt,
       nodeVersion,
       envList,
       installCommand,
       buildCommand,
+      bulidType,
+      lastCommitMessage,
     },
+  );
+
+  return data;
+};
+
+export const getUserDeployments = async (userId: string) => {
+  const { data } = await MainClient.get<DeploymentListResponse>(
+    `/deploy/${userId}`,
   );
 
   return data;

--- a/lib/recoil/userDeployments/atom.ts
+++ b/lib/recoil/userDeployments/atom.ts
@@ -1,0 +1,15 @@
+import { atom } from "recoil";
+import { getCookie } from "cookies-next";
+
+import { UserDeploymentData } from "../../../types";
+
+const userDeploymentsState = atom<UserDeploymentData[]>({
+  key: "userDeploymentsState",
+  default: getCookie("userDeployments")
+    ? (JSON.parse(
+        getCookie("userDeployments") as string,
+      ) as UserDeploymentData[])
+    : [],
+});
+
+export default userDeploymentsState;

--- a/lib/recoil/userDeployments/index.ts
+++ b/lib/recoil/userDeployments/index.ts
@@ -1,0 +1,3 @@
+import userDeploymentsState from "./atom";
+
+export default userDeploymentsState;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,10 +4,9 @@ import { useRecoilValue } from "recoil";
 
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-
 import { Typography } from "@mui/material";
+
 import NavBar from "../components/Navbar";
-import Dashboard from "./dashboard";
 import ButtonLogin from "../components/ButtonLogin";
 import { isLoggedInState } from "../lib/recoil/auth";
 
@@ -26,9 +25,7 @@ function PageLanding() {
 
   return (
     <Container maxWidth={false} disableGutters>
-      {!isSSR && isLoggedIn ? (
-        <Dashboard />
-      ) : (
+      {!isSSR && !isLoggedIn && (
         <>
           <NavBar />
           <Box

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,6 +27,7 @@ export type GitNamespace = {
 };
 
 export type GetOrgsResponse = {
+  result: string;
   data: GitNamespace[];
 };
 
@@ -34,9 +35,11 @@ export type Repo = {
   repoName: string;
   repoCloneUrl: string;
   repoUpdatedAt: string;
+  repoOwner?: string;
 };
 
 export type GetReposResponse = {
+  result: string;
   data: Repo[];
 };
 
@@ -58,8 +61,27 @@ export interface DeploymentOptions {
   installCommand?: string;
   buildCommand?: string;
   envList?: Env[];
+  bulidType?: string;
+  lastCommitMessage: string;
 }
 
 export interface RepoDeployOptions extends Repo, DeploymentOptions {
   userId: string;
+}
+
+export interface UserDeploymentData extends RepoDeployOptions {
+  instanceId: string;
+  deployedUrl?: string;
+  recordId?: string;
+  buildingLog?: (string | undefined)[] | undefined;
+}
+
+export interface DeploymentDataResponse {
+  result: string;
+  data: UserDeploymentData;
+}
+
+export interface DeploymentListResponse {
+  result: string;
+  data: UserDeploymentData[];
 }


### PR DESCRIPTION
## Task

- [필요한 백엔드 데이터베이스 작업](https://taewan.notion.site/74d0b6883f6c42c0be1f880531b41c24)

## Description

- 배포한 유저 데이터 보여줄 수 있도록 api 요청과 데이터베이스 로직 세팅
  - 대쉬보드 페이지
  - 로그인 페이지
- 대쉬보드 페이지에 유저 배포한 웹사이트 데이터 표시
  <img width="600" alt="Screenshot 2022-11-20 at 9 54 45 PM" src="https://user-images.githubusercontent.com/59520911/202902958-8f1d6826-0785-42dc-ab76-a41d45b62439.png">


## Key Points

- '/' 랜딩페이지 hydration 에러로 UI 분기처리 부분 수정했습니다
- 유저의 배포웹사이트 데이터 중 `buildingLog` 는 배열이 길어서 `setCookie()` 로 저장이 되지 않아서 빼고 저장했습니다. 
- 그래도 `buildingLog` 는 데이터베이스와 리코일 전역상태관리에 넣어두기 때문에, 상세페이지에서 필요하면 따로 요청하면 됩니다.

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- 
