### PR TITLE
✨ feat: add deleteUserDeployment feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/no-misused-promises": "warn",
+    "@typescript-eslint/no-unsafe-assignment": "warn",
     "@typescript-eslint/no-use-before-define": [
       "error",
       {

--- a/components/ButtonCreate.tsx
+++ b/components/ButtonCreate.tsx
@@ -1,9 +1,8 @@
 import { useRecoilValue, useSetRecoilState } from "recoil";
-
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-
 import { setCookie } from "cookies-next";
+
+import { Box, Button } from "@mui/material";
+
 import { getOrgs } from "../lib/api";
 import useModal from "../lib/hooks/useModal";
 

--- a/components/ModalAlert.tsx
+++ b/components/ModalAlert.tsx
@@ -1,0 +1,13 @@
+import { Alert, AlertTitle } from "@mui/material";
+
+function ModalAlert() {
+  return (
+    <Alert severity="success">
+      <AlertTitle>Success</AlertTitle>
+      Deployment is successfully deleted —{" "}
+      <strong>we will wait for your next deployment!</strong>
+    </Alert>
+  );
+}
+
+export default ModalAlert;

--- a/components/ModalBuild.tsx
+++ b/components/ModalBuild.tsx
@@ -165,7 +165,7 @@ function ModalBuild() {
                 labelId="select-label"
                 id="select"
                 value={version}
-                label="version"
+                label="Node Version"
                 sx={{ fontSize: "small" }}
                 autoFocus
                 onChange={handleVersionChange}
@@ -182,30 +182,30 @@ function ModalBuild() {
         </Box>
         <Box sx={{ width: "100%" }}>
           <Typography id="modal-description" variant="body2" sx={{ mt: 2 }}>
-            SSR Options *
+            CRA / Next Options *
           </Typography>
           <Box sx={{ width: "90%", marginTop: 1.5 }}>
             <FormControl size="small" fullWidth>
               <InputLabel id="select-label" sx={{ fontSize: "small" }}>
-                Is it SPA? or need SSR?
+                CRA / Next.js
               </InputLabel>
               <Select
                 labelId="select-label"
                 id="select"
                 value={buildType}
-                label="version"
+                label="CRA / Next.js"
                 sx={{ fontSize: "small" }}
                 autoFocus
                 onChange={handleBuildTypeChange}
               >
-                <MenuItem value="It is a SPA" sx={{ fontSize: "small" }}>
-                  It is a SPA
-                </MenuItem>
                 <MenuItem
-                  value="It needs SSR support"
+                  value="Create React App - SPA"
                   sx={{ fontSize: "small" }}
                 >
-                  It needs SSR support
+                  Create React App - SPA
+                </MenuItem>
+                <MenuItem value="Next.js App - SSR" sx={{ fontSize: "small" }}>
+                  Next.js App - SSR
                 </MenuItem>
               </Select>
             </FormControl>

--- a/components/ModalBuild.tsx
+++ b/components/ModalBuild.tsx
@@ -2,31 +2,34 @@ import { useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { setCookie } from "cookies-next";
 
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select, { SelectChangeEvent } from "@mui/material/Select";
-import TextField from "@mui/material/TextField";
-import Typography from "@mui/material/Typography";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ExpandMore as ExpandMoreIcon } from "@mui/icons-material";
 
 import { deployRepo } from "../lib/api";
 import useModal from "../lib/hooks/useModal";
 
+import loginState from "../lib/recoil/auth";
+import cloneUrlState, { cloneRepoName } from "../lib/recoil/git/clone";
+import userDeploymentsState from "../lib/recoil/userDeployments";
+
 import TextFieldAdd from "./TextFieldAdd";
 import TextFieldSaved from "./TextFieldSaved";
 
-import loginState from "../lib/recoil/auth";
-import cloneUrlState, { cloneRepoName } from "../lib/recoil/git/clone";
-
 import { Env, LoginData, UserDeploymentData } from "../types";
-import userDeploymentsState from "../lib/recoil/userDeployments";
 
 function ModalBuild() {
   const { data } =

--- a/components/ModalCreate.tsx
+++ b/components/ModalCreate.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select, { SelectChangeEvent } from "@mui/material/Select";
-import Typography from "@mui/material/Typography";
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+} from "@mui/material";
 
 import { getOrgRepos, getUserRepos } from "../lib/api";
 import useModal from "../lib/hooks/useModal";

--- a/components/ModalCreate.tsx
+++ b/components/ModalCreate.tsx
@@ -153,7 +153,7 @@ function ModalCreate() {
                 labelId="select-label"
                 id="select"
                 value={repository}
-                label="repository"
+                label="Select a Repository"
                 sx={{ fontSize: "small" }}
                 onChange={handleRepoChange}
               >

--- a/components/ModalDeleteConfirm.tsx
+++ b/components/ModalDeleteConfirm.tsx
@@ -43,7 +43,7 @@ function ModalDeleteConfirm({ ...modalProps }: IUserDeploymentData) {
   };
 
   return (
-    <Box sx={{ ...style }}>
+    <Box sx={{ ...BoxStyle }}>
       <Box
         display="flex"
         sx={{
@@ -77,17 +77,7 @@ function ModalDeleteConfirm({ ...modalProps }: IUserDeploymentData) {
         </Typography>
         <Button
           variant="contained"
-          sx={{
-            mt: 3,
-            bgcolor: "rgba(255, 83, 83, 0.8)",
-            width: "50%",
-            height: "2.5rem",
-            borderRadius: 1,
-            ":hover": {
-              bgcolor: "#FFF",
-              color: "#000",
-            },
-          }}
+          sx={{ ...ButtonStyle }}
           onClick={handleClickDelete}
         >
           Delete
@@ -97,7 +87,7 @@ function ModalDeleteConfirm({ ...modalProps }: IUserDeploymentData) {
   );
 }
 
-const style = {
+const BoxStyle = {
   position: "absolute" as const,
   top: "50%",
   left: "50%",
@@ -108,6 +98,18 @@ const style = {
   borderRadius: 3,
   boxShadow: 24,
   p: 4,
+};
+
+const ButtonStyle = {
+  mt: 3,
+  bgcolor: "rgba(255, 83, 83, 0.8)",
+  width: "50%",
+  height: "2.5rem",
+  borderRadius: 1,
+  ":hover": {
+    bgcolor: "#FFF",
+    color: "#000",
+  },
 };
 
 export default ModalDeleteConfirm;

--- a/components/ModalDeleteConfirm.tsx
+++ b/components/ModalDeleteConfirm.tsx
@@ -1,0 +1,109 @@
+import { useRecoilState, useRecoilValue } from "recoil";
+import { setCookie } from "cookies-next";
+
+import { Box, Button, Typography } from "@mui/material";
+
+import { deleteUserDeployment } from "../lib/api";
+import useModal from "../lib/hooks/useModal";
+
+import loginState from "../lib/recoil/auth";
+import userDeploymentsState from "../lib/recoil/userDeployments";
+
+import { LoginData, UserDeploymentData } from "../types";
+
+interface IUserDeploymentData {
+  cardData: UserDeploymentData;
+}
+
+function ModalDeleteConfirm({ ...modalProps }: IUserDeploymentData) {
+  const { data } =
+    useRecoilValue<LoginData | null>(loginState) || ({} as LoginData);
+  const [userDeploymentsList, setUserDeploymentsList] =
+    useRecoilState<UserDeploymentData[]>(userDeploymentsState);
+  const { showModal, hideModal } = useModal();
+
+  const userId = data._id;
+  const { cardData } = modalProps;
+
+  const handleClickDelete = async () => {
+    await deleteUserDeployment(userId, cardData.repoId as string);
+
+    const newUserDeploymentList = userDeploymentsList.filter(
+      item => item.repoCloneUrl !== cardData.repoCloneUrl,
+    );
+
+    setUserDeploymentsList(newUserDeploymentList);
+    setCookie("userDeployments", JSON.stringify(newUserDeploymentList));
+
+    hideModal();
+  };
+
+  return (
+    <Box sx={{ ...style }}>
+      <Box
+        display="flex"
+        sx={{
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Typography
+          id="modal-title"
+          variant="h5"
+          component="h3"
+          fontWeight="bold"
+        >
+          Delete Project
+        </Typography>
+        <Typography id="modal-description" sx={{ mt: 2, textAlign: "center" }}>
+          This project will be deleted, along with all of its Deployments,
+          Domains, Environment Variables, and Settings.
+        </Typography>
+        <Typography
+          id="modal-description"
+          sx={{
+            mt: 2,
+            textAlign: "center",
+            color: "rgba(255, 83, 83, 0.8)",
+            fontWeight: "bold",
+          }}
+        >
+          Warning: This action is not reversible. Please be certain.
+        </Typography>
+        <Button
+          variant="contained"
+          sx={{
+            mt: 3,
+            bgcolor: "rgba(255, 83, 83, 0.8)",
+            width: "50%",
+            height: "2.5rem",
+            borderRadius: 1,
+            ":hover": {
+              bgcolor: "#FFF",
+              color: "#000",
+            },
+          }}
+          onClick={handleClickDelete}
+        >
+          Delete
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+const style = {
+  position: "absolute" as const,
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "50vw",
+  bgcolor: "background.paper",
+  border: "1px solid #000",
+  borderRadius: 3,
+  boxShadow: 24,
+  p: 4,
+};
+
+export default ModalDeleteConfirm;

--- a/components/ModalDeleteConfirm.tsx
+++ b/components/ModalDeleteConfirm.tsx
@@ -36,6 +36,10 @@ function ModalDeleteConfirm({ ...modalProps }: IUserDeploymentData) {
     setCookie("userDeployments", JSON.stringify(newUserDeploymentList));
 
     hideModal();
+
+    showModal({
+      modalType: "ModalAlert",
+    });
   };
 
   return (

--- a/components/ModalDeploy.tsx
+++ b/components/ModalDeploy.tsx
@@ -2,16 +2,18 @@ import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 import { io, Socket } from "socket.io-client";
-import styled from "styled-components";
 
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import Typography from "@mui/material/Typography";
+import styled from "styled-components";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Divider,
+  Typography,
+} from "@mui/material";
+import { ExpandMore as ExpandMoreIcon } from "@mui/icons-material";
 
 import Config from "../lib/config";
 import useModal from "../lib/hooks/useModal";

--- a/components/ModalGlobal.tsx
+++ b/components/ModalGlobal.tsx
@@ -1,26 +1,34 @@
-import { Modal } from "@mui/material";
 import { useRecoilValue } from "recoil";
-import useModal from "../lib/hooks/useModal";
-import ModalBuild from "./ModalBuild";
-import ModalCreate from "./ModalCreate";
 
-import { modalState, ModalType } from "../lib/recoil/modal";
+import { Box, Modal } from "@mui/material";
+
+import useModal from "../lib/hooks/useModal";
+
+import ModalCreate from "./ModalCreate";
+import ModalBuild from "./ModalBuild";
 import ModalDeploy from "./ModalDeploy";
+import ModalDeleteConfirm from "./ModalDeleteConfirm";
+
+import { modalState } from "../lib/recoil/modal";
 
 function ModalGlobal() {
-  const { modalType } = useRecoilValue<ModalType | null>(modalState) || {};
+  const modal = useRecoilValue(modalState);
+  const { modalType, modalProps } = modal || {};
   const { isModal, hideModal } = useModal();
 
   const renderComponent = () => {
     switch (modalType) {
       case "ModalCreate":
-        return <ModalCreate />;
+        return <ModalCreate {...modalProps} />;
       case "ModalBuild":
-        return <ModalBuild />;
+        return <ModalBuild {...modalProps} />;
       case "ModalDeploy":
+        return <ModalDeploy {...modalProps} />;
+      case "ModalDeleteConfirm":
+        return <ModalDeleteConfirm {...modalProps} />;
         return <ModalDeploy />;
       default:
-        return <div />;
+        return null;
     }
   };
 
@@ -31,7 +39,7 @@ function ModalGlobal() {
       aria-labelledby="modal-title"
       aria-describedby="modal-description"
     >
-      {renderComponent()}
+      <Box>{renderComponent()}</Box>
     </Modal>
   );
 }

--- a/components/ModalGlobal.tsx
+++ b/components/ModalGlobal.tsx
@@ -8,6 +8,7 @@ import ModalCreate from "./ModalCreate";
 import ModalBuild from "./ModalBuild";
 import ModalDeploy from "./ModalDeploy";
 import ModalDeleteConfirm from "./ModalDeleteConfirm";
+import ModalAlert from "./ModalAlert";
 
 import { modalState } from "../lib/recoil/modal";
 
@@ -26,7 +27,8 @@ function ModalGlobal() {
         return <ModalDeploy {...modalProps} />;
       case "ModalDeleteConfirm":
         return <ModalDeleteConfirm {...modalProps} />;
-        return <ModalDeploy />;
+      case "ModalAlert":
+        return <ModalAlert {...modalProps} />;
       default:
         return null;
     }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -32,7 +32,7 @@ function NavBar() {
   };
 
   return (
-    <Box sx={{ flexGrow: 1 }}>
+    <Box sx={{ height: "10vh" }}>
       <AppBar
         position="relative"
         color="inherit"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,16 +1,17 @@
 import { useRouter } from "next/router";
 import { useRecoilValue, useSetRecoilState } from "recoil";
+import { deleteCookie } from "cookies-next";
 
-import { removeCookies } from "cookies-next";
-
-import AppBar from "@mui/material/AppBar";
-import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
-import ChangeHistoryIcon from "@mui/icons-material/ChangeHistory";
-import IconButton from "@mui/material/IconButton";
-import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import Tooltip from "@mui/material/Tooltip";
+import {
+  AppBar,
+  Box,
+  Button,
+  IconButton,
+  Toolbar,
+  Typography,
+  Tooltip,
+} from "@mui/material";
+import { ChangeHistory as ChangeHistoryIcon } from "@mui/icons-material";
 
 import loginState, { isLoggedInState } from "../lib/recoil/auth";
 
@@ -22,9 +23,9 @@ function NavBar() {
   const router = useRouter();
 
   const handleLogout = () => {
-    removeCookies("loginData");
-    removeCookies("userOrgs");
-    removeCookies("userDeployments");
+    deleteCookie("loginData");
+    deleteCookie("userOrgs");
+    deleteCookie("userDeployments");
     setIsLoggedIn(null);
 
     router.push("/login");

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -5,8 +5,17 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import Typography from "@mui/material/Typography";
 import CardActionArea from "@mui/material/CardActionArea";
 
-import { UserDeploymentData } from "../types";
+import { Box, CardContent, CardActionArea, Typography } from "@mui/material";
+import {
+  ChangeHistory as ChangeHistoryIcon,
+  Close as CloseIcon,
+  GitHub as GitHubIcon,
+} from "@mui/icons-material";
+
 import timeSince from "../lib/utils/timeSince";
+import useModal from "../lib/hooks/useModal";
+
+import { UserDeploymentData } from "../types";
 
 function RepoCard({ cardData }: { cardData: UserDeploymentData }) {
   const updatedMilliseconds = new Date(cardData.repoUpdatedAt).valueOf();

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -1,9 +1,4 @@
-import Box from "@mui/material/Box";
-import CardContent from "@mui/material/CardContent";
-import ChangeHistoryIcon from "@mui/icons-material/ChangeHistory";
-import GitHubIcon from "@mui/icons-material/GitHub";
-import Typography from "@mui/material/Typography";
-import CardActionArea from "@mui/material/CardActionArea";
+import { MouseEvent } from "react";
 
 import { Box, CardContent, CardActionArea, Typography } from "@mui/material";
 import {
@@ -17,16 +12,40 @@ import useModal from "../lib/hooks/useModal";
 
 import { UserDeploymentData } from "../types";
 
-function RepoCard({ cardData }: { cardData: UserDeploymentData }) {
+interface IUserDeploymentData {
+  cardData: UserDeploymentData;
+}
+
+function RepoCard({ cardData }: IUserDeploymentData) {
+  const { showModal } = useModal();
+
   const updatedMilliseconds = new Date(cardData.repoUpdatedAt).valueOf();
   const repoUpdatedSince = timeSince(updatedMilliseconds);
+
+  const handleCardClick = () => {};
+
+  const handleCloseButtonClick = (e: MouseEvent) => {
+    e.stopPropagation();
+
+    showModal({
+      modalType: "ModalDeleteConfirm",
+      modalProps: {
+        cardData,
+      },
+    });
+
+    console.info("Close button is clicked!");
+  };
 
   return (
     <CardActionArea onClick={handleCardClick}>
       <CardContent
         sx={{ position: "relative", padding: "1.5rem", height: 180 }}
       >
-        <CloseIcon sx={{ ...CloseIconStyle }} onClick={handleCloseClick} />
+        <CloseIcon
+          sx={{ ...CloseIconStyle }}
+          onClick={handleCloseButtonClick}
+        />
         <Box
           sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
         >

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -22,32 +22,55 @@ function RepoCard({ cardData }: { cardData: UserDeploymentData }) {
   const repoUpdatedSince = timeSince(updatedMilliseconds);
 
   return (
-    <CardActionArea>
-      <CardContent sx={{ padding: 0, margin: 2 }}>
-        <Box display="flex" sx={{ flexDirection: "row", alignItems: "center" }}>
+    <CardActionArea onClick={handleCardClick}>
+      <CardContent
+        sx={{ position: "relative", padding: "1.5rem", height: 180 }}
+      >
+        <CloseIcon sx={{ ...CloseIconStyle }} onClick={handleCloseClick} />
+        <Box
+          sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}
+        >
           <ChangeHistoryIcon fontSize="medium" />
-          <Box display="flex" sx={{ flexDirection: "column", marginLeft: 1 }}>
-            <Typography fontSize="large" fontWeight="bold">
+          <Box sx={{ display: "flex", flexDirection: "column", marginLeft: 1 }}>
+            <Typography sx={{ fontSize: "large", fontWeight: "bold" }}>
               {cardData.repoName}
             </Typography>
-            <Typography fontSize="medium">{cardData.deployedUrl}</Typography>
+            <Typography sx={{ fontSize: "medium" }}>
+              {cardData.deployedUrl}
+            </Typography>
           </Box>
         </Box>
-        <Typography fontSize="small" fontWeight="medium" sx={{ marginTop: 2 }}>
+        <Typography sx={{ fontSize: "small", fontWeight: "medium", mt: 2 }}>
           {cardData.lastCommitMessage}
         </Typography>
         <Box
-          display="flex"
-          sx={{ flexDirection: "row", marginTop: 2, alignItems: "center" }}
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            mt: 2,
+          }}
         >
-          <Typography fontSize="small" fontWeight="medium">
+          <Typography sx={{ fontSize: "small", fontWeight: "medium" }}>
             {repoUpdatedSince} ago via
           </Typography>
-          <GitHubIcon fontSize="small" sx={{ marginLeft: 0.5 }} />
+          <GitHubIcon sx={{ fontSize: "small", marginLeft: 0.5 }} />
         </Box>
       </CardContent>
     </CardActionArea>
   );
 }
+
+const CloseIconStyle = {
+  position: "absolute",
+  top: "0.5rem",
+  right: "0.5rem",
+  color: "rgba(51, 51, 51, 0.8)",
+  width: "1.2rem",
+  "&:hover": {
+    color: "rgba(255, 83, 83, 0.8)",
+    backgroundColor: "white",
+  },
+};
 
 export default RepoCard;

--- a/components/RepoCardList.tsx
+++ b/components/RepoCardList.tsx
@@ -14,23 +14,27 @@ function RepoCardList({
   const [cardDataList] = useState<UserDeploymentData[]>(userDeploymentsList);
 
   return (
-    <Box display="flex" sx={{ flexDirection: "row" }}>
-      {cardDataList.map((cardData, index) => {
+    <Grid
+      container
+      spacing={{ xs: 2, md: 3 }}
+      columns={{ xs: 4, sm: 8, md: 12 }}
+      sx={{
+        height: "80vh",
+        overflow: "auto",
+        paddingRight: "0.1rem",
+        paddingLeft: "0.1rem",
+      }}
+    >
+      {userDeploymentList.map((cardData, index) => {
         return (
-          <Box
-            key={index}
-            sx={{
-              padding: 1,
-              margin: 1,
-            }}
-          >
+          <Grid item xs={2} sm={4} md={4} key={index}>
             <Card variant="elevation">
               <RepoCard cardData={cardData} />
             </Card>
-          </Box>
+          </Grid>
         );
       })}
-    </Box>
+    </Grid>
   );
 }
 

--- a/components/RepoCardList.tsx
+++ b/components/RepoCardList.tsx
@@ -1,17 +1,13 @@
-import { useState } from "react";
+import { useRecoilValue } from "recoil";
 
 import { Card, Grid } from "@mui/material";
 
 import RepoCard from "./RepoCard";
 
-import { UserDeploymentData } from "../types";
+import userDeploymentsState from "../lib/recoil/userDeployments";
 
-function RepoCardList({
-  userDeploymentsList,
-}: {
-  userDeploymentsList: UserDeploymentData[];
-}) {
-  const [cardDataList] = useState<UserDeploymentData[]>(userDeploymentsList);
+function RepoCardList() {
+  const userDeploymentList = useRecoilValue(userDeploymentsState);
 
   return (
     <Grid

--- a/components/RepoCardList.tsx
+++ b/components/RepoCardList.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
-import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";
+import { Card, Grid } from "@mui/material";
 
 import RepoCard from "./RepoCard";
 

--- a/components/SearchInput.tsx
+++ b/components/SearchInput.tsx
@@ -1,6 +1,5 @@
-import InputAdornment from "@mui/material/InputAdornment";
-import SearchIcon from "@mui/icons-material/Search";
-import TextField from "@mui/material/TextField";
+import { InputAdornment, TextField } from "@mui/material";
+import { Search as SearchIcon } from "@mui/icons-material";
 
 function SearchInput() {
   return (

--- a/components/TemplateInitial.tsx
+++ b/components/TemplateInitial.tsx
@@ -1,10 +1,13 @@
-import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";
-import CardActionArea from "@mui/material/CardActionArea";
-import CardContent from "@mui/material/CardContent";
-import CardMedia from "@mui/material/CardMedia";
-import ChangeHistoryIcon from "@mui/icons-material/ChangeHistory";
-import Typography from "@mui/material/Typography";
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Typography,
+} from "@mui/material";
+import { ChangeHistory as ChangeHistoryIcon } from "@mui/icons-material";
+
 import { Image, imageList } from "../imageList";
 
 function DummyImage({ image }: { image: Image }) {

--- a/components/TextFieldAdd.tsx
+++ b/components/TextFieldAdd.tsx
@@ -1,10 +1,7 @@
 import { ChangeEvent, useState } from "react";
 
-import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import TextField from "@mui/material/TextField";
-import AddIcon from "@mui/icons-material/Add";
-import IconButton from "@mui/material/IconButton";
+import { Box, FormControl, IconButton, TextField } from "@mui/material";
+import { Add as AddIcon } from "@mui/icons-material";
 
 import { EnvsState } from "../types";
 

--- a/components/TextFieldSaved.tsx
+++ b/components/TextFieldSaved.tsx
@@ -1,8 +1,5 @@
-import Box from "@mui/material/Box";
-import FormControl from "@mui/material/FormControl";
-import TextField from "@mui/material/TextField";
-import IconButton from "@mui/material/IconButton";
-import RemoveIcon from "@mui/icons-material/Remove";
+import { Box, FormControl, IconButton, TextField } from "@mui/material";
+import { Remove as RemoveIcon } from "@mui/icons-material";
 
 import { EnvsState } from "../types";
 

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -72,6 +72,10 @@ export const getOrgRepos = async (userId: string, org: string) => {
   return data;
 };
 
+export const deleteUserDeployment = async (userId: string, repoId: string) => {
+  await MainClient.delete(`/users/${userId}/${repoId}`);
+};
+
 export const deployRepo = async (userBuildOptions: RepoDeployOptions) => {
   const {
     userId,

--- a/lib/hooks/useModal.ts
+++ b/lib/hooks/useModal.ts
@@ -4,8 +4,8 @@ import { modalState, ModalType } from "../recoil/modal";
 function useModal() {
   const [isModal, setIsModal] = useRecoilState(modalState);
 
-  const showModal = (modalTypeObj: ModalType) => {
-    setIsModal(modalTypeObj);
+  const showModal = ({ modalType, modalProps }: ModalType) => {
+    setIsModal({ modalType, modalProps });
   };
 
   const hideModal = () => {

--- a/lib/recoil/modal.ts
+++ b/lib/recoil/modal.ts
@@ -4,21 +4,40 @@ export const MODAL_TYPES = {
   ModalCreate: "ModalCreate",
   ModalBuild: "ModalBuild",
   ModalDeploy: "ModalDeploy",
+  ModalDeleteConfirm: "ModalDeleteConfirm",
+  ModalAlert: "ModalAlert",
 } as const;
 
 export interface ModalCreateType {
   modalType: typeof MODAL_TYPES.ModalCreate;
+  modalProps?: any;
 }
 
 export interface ModalBuildType {
   modalType: typeof MODAL_TYPES.ModalBuild;
+  modalProps?: any;
 }
 
 export interface ModalDeployType {
   modalType: typeof MODAL_TYPES.ModalDeploy;
+  modalProps?: any;
 }
 
-export type ModalType = ModalCreateType | ModalBuildType | ModalDeployType;
+export interface ModalDeleteType {
+  modalType: typeof MODAL_TYPES.ModalDeleteConfirm;
+  modalProps?: any;
+}
+export interface ModalAlertType {
+  modalType: typeof MODAL_TYPES.ModalAlert;
+  modalProps?: any;
+}
+
+export type ModalType =
+  | ModalCreateType
+  | ModalBuildType
+  | ModalDeployType
+  | ModalDeleteType
+  | ModalAlertType;
 
 export const modalState = atom<ModalType | null>({
   key: "modalState",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,13 @@
 import type { AppProps } from "next/app";
-
 import { RecoilRoot } from "recoil";
-import CssBaseline from "@mui/material/CssBaseline";
-import { ThemeProvider, createTheme } from "@mui/material";
-import ModalGlobal from "../components/ModalGlobal";
+
 import "../public/fonts/style.css";
+import { ThemeProvider, CssBaseline } from "@mui/material";
+import theme from "../utils/theme";
+
+import ModalGlobal from "../components/ModalGlobal";
 
 export default function App({ Component, pageProps }: AppProps) {
-  const theme = createTheme({
-    typography: {
-      fontFamily: "Pretendard-Regular",
-    },
-  });
-
   return (
     <ThemeProvider theme={theme}>
       <RecoilRoot>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -82,11 +82,9 @@ function Dashboard() {
               <ButtonCreate />
             </Box>
             {userDeploymentsList.length > 0 ? (
-              <RepoCardList userDeploymentsList={userDeploymentsList} />
+              <RepoCardList />
             ) : (
-              <Box sx={{ width: "100%" }}>
-                <TemplateInitial />
-              </Box>
+              <Box sx={{ width: "100%" }}>{/* //   <TemplateInitial /> */}</Box>
             )}
           </Container>
         </>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -67,7 +67,7 @@ function Dashboard() {
         <>
           <NavBar />
           <Divider />
-          <Container fixed maxWidth="lg">
+          <Container fixed maxWidth="lg" sx={{ height: "90vh" }}>
             <Box
               display="flex"
               sx={{
@@ -75,6 +75,7 @@ function Dashboard() {
                 flexDirection: "row",
                 justifyContent: "center",
                 alignItems: "center",
+                marginBottom: "1rem",
               }}
             >
               <SearchInput />

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -3,9 +3,8 @@ import { useRouter } from "next/router";
 import { useRecoilValue, useRecoilState } from "recoil";
 import { setCookie } from "cookies-next";
 
-import Box from "@mui/material/Box";
-import Container from "@mui/material/Container";
-import Divider from "@mui/material/Divider";
+import { Box, Container, Divider } from "@mui/material";
+
 import ButtonCreate from "../components/ButtonCreate";
 import RepoCardList from "../components/RepoCardList";
 import NavBar from "../components/Navbar";
@@ -13,10 +12,10 @@ import SearchInput from "../components/SearchInput";
 import TemplateInitial from "../components/TemplateInitial";
 
 import Login from "./login";
-import loginState, { isLoggedInState } from "../lib/recoil/auth";
-import userDeploymentsState from "../lib/recoil/userDeployments";
 
 import { getUserDeployments } from "../lib/api";
+import loginState, { isLoggedInState } from "../lib/recoil/auth";
+import userDeploymentsState from "../lib/recoil/userDeployments";
 
 import { LoginData, UserDeploymentData } from "../types";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,11 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { useRecoilValue } from "recoil";
 
-import Box from "@mui/material/Box";
-import Container from "@mui/material/Container";
-import { Typography } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 
 import NavBar from "../components/Navbar";
 import ButtonLogin from "../components/ButtonLogin";
+
 import { isLoggedInState } from "../lib/recoil/auth";
 
 function PageLanding() {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,11 +3,8 @@ import { useRouter } from "next/router";
 import { useSetRecoilState } from "recoil";
 import { setCookie } from "cookies-next";
 
-import Container from "@mui/material/Container";
+import { Box, Container, Divider, Typography } from "@mui/material";
 
-import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
-import Typography from "@mui/material/Typography";
 import { getUserDeployments, login } from "../lib/api";
 import loginState from "../lib/recoil/auth";
 import userDeploymentsState from "../lib/recoil/userDeployments";

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -78,7 +78,7 @@ function Login() {
             }}
           >
             <Typography variant="h4" sx={{ fontWeight: "bold" }}>
-              Log in to Vercel
+              Login to Jaam Toast
             </Typography>
             <Box sx={{ padding: 5 }}>
               <ButtonLogin />

--- a/types/index.ts
+++ b/types/index.ts
@@ -74,6 +74,7 @@ export interface UserDeploymentData extends RepoDeployOptions {
   deployedUrl?: string;
   recordId?: string;
   buildingLog?: (string | undefined)[] | undefined;
+  repoId?: string;
 }
 
 export interface DeploymentDataResponse {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,0 +1,9 @@
+import { createTheme } from "@mui/material/styles";
+
+const theme = createTheme({
+  typography: {
+    fontFamily: "Pretendard-Regular",
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Task

- [유저배포 삭제 & 배포 중 에러 시 롤백](https://taewan.notion.site/42ec3577f1614a3fb38cbd43ea75e354)

## Description

- 유저배포 삭제 관련 UI
- 유저배포 삭제 요청 기능
- 유저배포 삭제에 따른 상태 관리
- `modalProps` 사용으로 `GlobalModal` 과 `useModal` 수정

## Key Points

- [Minimizing bundle size](https://mui.com/material-ui/guides/minimizing-bundle-size/) 를 위해 MUI default import 를 named imports 로 수정 진행 (Tree-shaking of MUI 지원해줌)
  - 때문에 development environment 에서는 development startup times 가 더 느려질 수 있습니다
- UI flickering 이 있어서 MUI theme 관련 SSR 적용을 위해 수정을 진행하다가 일정 버전 이상은 불필요한 작업인 것을 확인하고 다시 재수정 했습니다—[관련 링크](https://emotion.sh/docs/ssr#nextjs)
  - _[For v10 and above, SSR just works in Next.js](https://emotion.sh/docs/ssr#nextjs:~:text=For%20v10%20and%20above%2C%20SSR%20just%20works%20in%20Next.js)_

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- 
