### PR TITLE
✨ feat: p1; ProjectDetail, ProjectSettings page add static page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaam-toast-frontend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/@shared/DashboardHeader.css.ts
+++ b/src/@shared/DashboardHeader.css.ts
@@ -1,0 +1,30 @@
+import { style } from "@vanilla-extract/css";
+import { s } from "../@styles";
+import * as colors from "../@config/colors";
+
+export const container = style([
+  s.flexColumn,
+  {
+    gap: "2rem",
+    paddingBottom: "1.5rem",
+  },
+]);
+
+export const projectTitle = style({
+  fontSize: "2rem",
+});
+
+export const dashboardNavBar = style([
+  s.flex,
+  { gap: "0.5rem", listStyle: "none" },
+]);
+
+export const dashboardNavLink = style([
+  s.border,
+  {
+    backgroundColor: colors.WHITE,
+    padding: "0.6rem 1.5rem",
+    fontWeight: 500,
+    fontSize: "0.8rem",
+  },
+]);

--- a/src/@shared/DashboardHeader.tsx
+++ b/src/@shared/DashboardHeader.tsx
@@ -1,0 +1,25 @@
+import { Link, Navigate, useParams } from "react-router-dom";
+import * as css from "./DashboardHeader.css";
+
+export function DashboardHeader() {
+  const params = useParams();
+  const { userName, projectName } = params;
+
+  if (!projectName || !userName) {
+    return <Navigate to="/error" />;
+  }
+
+  return (
+    <div className={css.container}>
+      <ul className={css.dashboardNavBar}>
+        <li className={css.dashboardNavLink}>
+          <Link to={`/${userName}/${projectName}`}>Project</Link>
+        </li>
+        <li className={css.dashboardNavLink}>
+          <Link to={`/${userName}/${projectName}/settings`}>Settings</Link>
+        </li>
+      </ul>
+      <h1 className={css.projectTitle}>{projectName?.toUpperCase()}</h1>
+    </div>
+  );
+}

--- a/src/@shared/EnvField.css.ts
+++ b/src/@shared/EnvField.css.ts
@@ -31,7 +31,7 @@ export const envList = style([
 ]);
 
 export const envKey = style([
-  s.boder,
+  s.border,
   {
     padding: "0.7rem 2rem",
     width: "25%",
@@ -43,7 +43,7 @@ export const envKey = style([
 ]);
 
 export const envValue = style([
-  s.boder,
+  s.border,
   {
     padding: "0.7rem 2rem",
     width: "100%",

--- a/src/@shared/SelectBox.css.ts
+++ b/src/@shared/SelectBox.css.ts
@@ -6,7 +6,7 @@ export const container = style([
   s.flex,
   s.alignItemsCenter,
   s.fullWidth,
-  s.boder,
+  s.border,
   s.poiner,
   {
     position: "relative",

--- a/src/@shared/index.ts
+++ b/src/@shared/index.ts
@@ -5,6 +5,7 @@ export { EnvField } from "./EnvField";
 export { Header } from "./Header";
 export { SelectBox } from "./SelectBox";
 export { TextField } from "./TextField";
+export { DashboardHeader } from "./DashboardHeader";
 
 export { useAuth } from "./useAuth";
 export * from "./useProjectNameStore";

--- a/src/@styles/styles.css.ts
+++ b/src/@styles/styles.css.ts
@@ -58,7 +58,7 @@ export const scroll = style({
   },
 });
 
-export const boder = style({
+export const border = style({
   border: `1px solid ${colors.BLACK}`,
   borderRadius: "1.5rem",
 });

--- a/src/BuildOptionSelect/index.css.ts
+++ b/src/BuildOptionSelect/index.css.ts
@@ -43,7 +43,7 @@ export const completeButton = style([
 
 export const buildOption = style([
   s.flexColumn,
-  s.boder,
+  s.border,
   {
     gap: "1rem",
     padding: "1.5rem",

--- a/src/ProjectDeploy/index.css.ts
+++ b/src/ProjectDeploy/index.css.ts
@@ -23,7 +23,7 @@ export const subTitle = style({
 
 export const buildLogSection = style([
   s.flexColumn,
-  s.boder,
+  s.border,
   s.poiner,
   {
     gap: "1rem",
@@ -41,7 +41,7 @@ export const mainSection = style([s.flex, { gap: "1rem" }]);
 
 export const buildLogList = style([
   s.flexColumn,
-  s.boder,
+  s.border,
   s.scroll,
   {
     padding: "2rem",
@@ -67,7 +67,7 @@ export const log = style({
 
 export const previewSection = style([
   s.flexColumn,
-  s.boder,
+  s.border,
   {
     gap: "1rem",
     padding: "2rem",
@@ -76,7 +76,7 @@ export const previewSection = style([
 ]);
 
 export const preview = style([
-  s.boder,
+  s.border,
   {
     width: "100%",
     aspectRatio: "1920 / 1280",

--- a/src/ProjectDetail/index.css.ts
+++ b/src/ProjectDetail/index.css.ts
@@ -16,9 +16,9 @@ export const projectDetails = style([s.flex, { gap: "1rem" }]);
 export const projectInfoSection = style([
   s.border,
   s.flexColumn,
-  s.flexSpaceBetween,
   {
     padding: "3rem 3rem 2rem",
+    gap: "2rem",
     width: "90%",
     listStyle: "none",
     backgroundColor: colors.BLACK,

--- a/src/ProjectDetail/index.css.ts
+++ b/src/ProjectDetail/index.css.ts
@@ -1,0 +1,48 @@
+import { style } from "@vanilla-extract/css";
+import { s } from "../@styles";
+import * as colors from "../@config/colors";
+
+export const container = style([
+  s.fullWidth,
+  s.flexColumn,
+  {
+    gap: "1rem",
+    padding: "5rem 15vw",
+  },
+]);
+
+export const projectDetails = style([s.flex, { gap: "1rem" }]);
+
+export const projectInfoSection = style([
+  s.border,
+  s.flexColumn,
+  s.flexSpaceBetween,
+  {
+    padding: "3rem 3rem 2rem",
+    width: "90%",
+    listStyle: "none",
+    backgroundColor: colors.BLACK,
+    color: colors.WHITE,
+    userSelect: "none",
+  },
+]);
+
+export const projectInfoSectionTitle = style({
+  fontWeight: 500,
+  fontSize: "1.4rem",
+  textTransform: "uppercase",
+});
+
+export const projectInfoList = style([s.flexColumn, { gap: "1rem" }]);
+
+export const projectInfo = style([s.flexColumn, { gap: "0.3rem" }]);
+
+export const projectInfoTitle = style({
+  fontSize: "0.8rem",
+  fontWeight: 500,
+  textTransform: "uppercase",
+});
+
+export const projectInfoText = style({
+  fontSize: "0.95rem",
+});

--- a/src/ProjectDetail/index.tsx
+++ b/src/ProjectDetail/index.tsx
@@ -1,49 +1,70 @@
-import { useEffect } from "react";
-import { useProjectQuery } from "../ProjectDetail/useProjectQuery";
-import { useNavigate, useParams } from "react-router-dom";
+// import { useProjectQuery } from "../ProjectDetail/useProjectQuery";
+import { Suspense } from "react";
+import { Navigate, useParams } from "react-router-dom";
+
+import { DashboardHeader } from "../@shared";
+import { Preview, PreviewSkeleton } from "../ProjectDeploy/Preview";
+import * as css from "./index.css";
 
 export function ProjectDetail() {
-  const navigate = useNavigate();
   const params = useParams();
   const { projectName } = params;
-  const { data: project } = useProjectQuery(projectName!);
 
-  useEffect(() => {
-    if (!params.projectName) {
-      navigate("/");
-    }
-  }, []);
+  if (!projectName) {
+    return <Navigate to="/" />;
+  }
+
+  // const { data: project } = useProjectQuery(projectName);
+  const MOCK_PROJECT = {
+    projectName: "MOCK_PROJECT",
+    repoName: "MOCK_REPO",
+    space: "MOCK_SPACE",
+    repoCloneUrl: "https://MOCK_PROJECT/MOCK_PROJECT.github.com",
+    projectUpdatedAt: "123",
+    nodeVersion: "12.18.0",
+    buildType: "react",
+    deployedUrl: "https://www.jaamtoast.click",
+    lastCommitMessage: "hello",
+  };
+
+  const project = MOCK_PROJECT;
 
   return (
-    <div>
-      <div>
-        <div>
-          <div>
-            <p>Preview</p>
-          </div>
-          <div>
-            <div>
-              <iframe
-                title="jaam-toast-preview"
-                src={`https://${project?.deployedUrl}`}
-                style={{
-                  width: "100%",
-                  height: "100%",
-                }}
-                sandbox="allow-scripts"
-                loading="eager"
-                frameBorder="0"
-              />
-            </div>
-          </div>
-          <p>{`https://${project?.deployedUrl}`}</p>
-          {/* <PreviewCommandsTextField
-            installCommand={project?.installCommand}
-            buildCommand={project?.buildCommand}
-          />
-          <PreviewEnvList envsList={project?.envList} />
-          <BuildingLog buildingLog={project?.buildingLog} /> */}
-        </div>
+    <div className={css.container}>
+      <DashboardHeader />
+      <div className={css.projectDetails}>
+        <PreviewSkeleton />
+        <section className={css.projectInfoSection}>
+          <span className={css.projectInfoSectionTitle}>
+            project informations
+          </span>
+          <ul className={css.projectInfoList}>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>name</span>
+              <p className={css.projectInfoText}>{projectName}</p>
+            </li>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>package info</span>
+              <p className={css.projectInfoText}>{project.buildType}</p>
+            </li>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>url</span>
+              <p className={css.projectInfoText}>{project.deployedUrl}</p>
+            </li>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>status</span>
+              <p className={css.projectInfoText}>READY</p>
+            </li>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>last commit message</span>
+              <p className={css.projectInfoText}>{project.lastCommitMessage}</p>
+            </li>
+            <li className={css.projectInfo}>
+              <span className={css.projectInfoTitle}>created at</span>
+              <p className={css.projectInfoText}>{project.projectUpdatedAt}</p>
+            </li>
+          </ul>
+        </section>
       </div>
     </div>
   );

--- a/src/ProjectDetail/useProjectQuery.tsx
+++ b/src/ProjectDetail/useProjectQuery.tsx
@@ -17,15 +17,3 @@ export function useProjectQuery(projectName: string) {
     queryFn: () => api.getProject(projectName),
   });
 }
-
-export function projectPrefetchQuery(user: User, projectName: string) {
-  const api = new APIClient()
-    .setUserId(user?.id)
-    .setAccessToken(user?.accessToken)
-    .setGithubAccessToken(user?.githubAccessToken);
-
-  return {
-    queryKey: ["project", projectName],
-    queryFn: () => api.getProject(projectName),
-  };
-}

--- a/src/ProjectList/ProjectCardList.tsx
+++ b/src/ProjectList/ProjectCardList.tsx
@@ -48,7 +48,7 @@ export function ProjectCardList({ searchword }: ProjectCardListProps) {
                 {project.lastCommitMessage}
               </p>
               <span className={css.projectCardUpdatedAt}>
-                {timeSince(Number(project.projectUpdatedAt))} ago via
+                {timeSince(Number(project.projectUpdatedAt))}
               </span>
             </div>
           </div>

--- a/src/ProjectSettings/index.css.ts
+++ b/src/ProjectSettings/index.css.ts
@@ -1,0 +1,84 @@
+import { style } from "@vanilla-extract/css";
+import { s } from "src/@styles";
+import * as colors from "../@config/colors";
+
+export const container = style([
+  s.flexColumn,
+  {
+    padding: "5rem 15vw",
+    gap: "1rem",
+  },
+]);
+
+export const settingOptionSection = style([
+  s.border,
+  s.flexColumn,
+  { gap: "1.5rem", padding: "1.5rem 2rem", backgroundColor: colors.LAVENDER },
+]);
+
+export const sectionHead = style([s.flex, s.flexSpaceBetween]);
+
+export const sectionTitle = style({
+  fontWeight: 500,
+  textTransform: "uppercase",
+});
+
+export const saveButton = style([
+  s.button,
+  s.buttonSize.small,
+  s.buttonColor.dark,
+]);
+
+export const addDomainField = style([
+  s.flex,
+  s.flexSpaceBetween,
+  {
+    gap: "0.3rem",
+    paddingBottom: "1rem",
+    borderBottom: `1px solid ${colors.BLACK}`,
+  },
+]);
+
+export const addButton = style([
+  s.button,
+  s.buttonSize.medium,
+  s.buttonColor.dark,
+]);
+
+export const domainList = style([
+  s.flexColumn,
+  {
+    listStyle: "none",
+    gap: "0.4rem",
+  },
+]);
+
+export const domain = style([
+  s.border,
+  {
+    backgroundColor: colors.BLACK,
+    height: "2.5rem",
+    lineHeight: "2.5rem",
+    padding: "0 1.5rem",
+    color: colors.WHITE,
+    userSelect: "none",
+  },
+]);
+
+export const deleteProjectSection = style({
+  backgroundColor: colors.STRAWBERRY,
+  gap: "1.5rem",
+});
+
+export const sectionDescription = style({
+  fontSize: "0.9rem",
+});
+
+export const deleteProjectButton = style([
+  s.button,
+  s.buttonSize.small,
+  {
+    backgroundColor: "red",
+    color: colors.WHITE,
+  },
+]);

--- a/src/ProjectSettings/index.tsx
+++ b/src/ProjectSettings/index.tsx
@@ -1,0 +1,65 @@
+import { DashboardHeader, EnvField, TextField } from "../@shared";
+import * as css from "./index.css";
+
+export function ProjectSettings() {
+  const domainList = ["www.jaamtoast.click", "www.google.com"];
+
+  return (
+    <div className={css.container}>
+      <DashboardHeader />
+
+      <section className={css.settingOptionSection}>
+        <div className={css.sectionHead}>
+          <span className={css.sectionTitle}>Build Command</span>
+          <button className={css.saveButton}>save</button>
+        </div>
+        <TextField placeholder="npm run build" />
+      </section>
+
+      <section className={css.settingOptionSection}>
+        <div className={css.sectionHead}>
+          <span className={css.sectionTitle}>Install Command</span>
+          <button className={css.saveButton}>save</button>
+        </div>
+        <TextField placeholder="npm install" />
+      </section>
+
+      <section className={css.settingOptionSection}>
+        <div className={css.sectionHead}>
+          <span className={css.sectionTitle}>Environtment Variables</span>
+          <button className={css.saveButton}>save</button>
+        </div>
+        <EnvField />
+      </section>
+
+      <section className={css.settingOptionSection}>
+        <div className={css.sectionHead}>
+          <span className={css.sectionTitle}>Domains</span>
+        </div>
+        <div className={css.addDomainField}>
+          <TextField />
+          <button className={css.addButton}>add</button>
+        </div>
+        <ul className={css.domainList}>
+          {domainList.map(domain => (
+            <li className={css.domain}>{domain}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        className={`${css.settingOptionSection} ${css.deleteProjectSection}`}
+      >
+        <div className={css.sectionHead}>
+          <span className={css.sectionTitle}>Delete Project</span>
+        </div>
+        <p className={css.sectionDescription}>
+          Once you delete a project, there is no going back. Please be certain.
+        </p>
+        <button className={css.deleteProjectButton}>
+          delete project permanently
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/RepositorySelect/RepositoryList.css.ts
+++ b/src/RepositorySelect/RepositoryList.css.ts
@@ -6,7 +6,7 @@ export const container = style([s.full]);
 
 export const repoOptionList = style([
   s.full,
-  s.boder,
+  s.border,
   s.scroll,
   {
     overflow: "scroll",

--- a/src/RepositorySelect/index.css.ts
+++ b/src/RepositorySelect/index.css.ts
@@ -46,7 +46,7 @@ export const selectMessage = style([
   s.flex,
   s.flexCenter,
   s.full,
-  s.boder,
+  s.border,
   {
     backgroundColor: colors.WHITE,
     fontSize: "1.1rem",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { Suspense } from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { Header } from "./@shared/Header";
 import { Landing } from "./Landing";
@@ -8,6 +8,7 @@ import { RepositorySelect } from "./RepositorySelect";
 import { BuildOptionSelect } from "./BuildOptionSelect";
 import { ProjectDeploy } from "./ProjectDeploy";
 import { ProjectDetail } from "./ProjectDetail";
+import { ProjectSettings } from "./ProjectSettings";
 import { NotFound } from "./Error/NotFound";
 import { Error } from "./Error";
 import { useAuth } from "./@shared";
@@ -42,6 +43,10 @@ export function App() {
             element={<ProjectDeploy />}
           />
           <Route path="/:userName/:projectName" element={<ProjectDetail />} />
+          <Route
+            path="/:userName/:projectName/settings"
+            element={<ProjectSettings />}
+          />
           <Route
             path="/error"
             element={<Error code={state?.code} message={state?.message} />}


### PR DESCRIPTION
## Task

- ✨ feat: p1; ProjectDetail, ProjectSettings page add static page.

## Description

- static 페이지들을 작업하였습니다. 별도로 기능 연결은 되지 않은 상태입니다.
- DashboardHeader 컴포넌트를 작성해, 각 dashboard 페이지에서 사용될 header들을 정의하였습니다.(@shared에 위치)
- ProjectDetail page(프로젝트 미리 보기 및 상세 정보 제공) mark up 입니다.
<img width="1408" alt="Screenshot 2023-04-16 at 21 16 12" src="https://user-images.githubusercontent.com/79369983/232309512-9d5cf53e-deae-49df-8910-e811ac8b6aa7.png">
<br />

- ProjectSettings page(프로젝트 환경 설정 수정 및 세팅) mark up 입니다.
<img width="1383" alt="Screenshot 2023-04-16 at 21 15 26" src="https://user-images.githubusercontent.com/79369983/232309508-f76886ac-c3bd-4e43-81d8-d68c02128aa2.png">
<br />

- 그 이외에 오타 수정하였습니다.

## Checklist - reusable and pure functions

- [x] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- [기타 논의 사항]
