### PR TITLE
♻️ refactor: migrate Github Oauth Apps to Github Apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaam-toast-frontend",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/@hooks/usePresetBuildOptionStore.ts
+++ b/src/@hooks/usePresetBuildOptionStore.ts
@@ -5,10 +5,12 @@ import { customAlphabet } from "nanoid";
 
 import { useAuth } from "./useAuth";
 import APIClient from "../@utils/api";
-import { Framework, NodeVersion } from "../@types/build";
+
+import type { Framework, NodeVersion } from "../@types/build";
+import type { Space } from "../@types/api";
 
 export type PresetBuildOptionStore = {
-  space: string | null;
+  space: Space | null;
   repoName: string | null;
   defaultProjectName: string | null;
   defaultFramework: Framework | null;
@@ -17,7 +19,7 @@ export type PresetBuildOptionStore = {
   defaultNodeVersion: NodeVersion;
 
   actions: {
-    setSpace: (space: string) => void;
+    setSpace: (space: Space) => void;
     setRepoName: (repoName: string) => void;
     setDefaultCommand: (setDefaultCommandOptions: {
       installCommand: string;
@@ -37,7 +39,7 @@ export const usePresetBuildOptionStore = create<PresetBuildOptionStore>()(
     defaultNodeVersion: "12.18.0",
 
     actions: {
-      setSpace: (space: string) => {
+      setSpace: (space: Space) => {
         set({ space });
       },
       setRepoName: async (repoName: string) => {
@@ -117,13 +119,13 @@ export const useReposQuery = () => {
     .setGithubAccessToken(user?.githubAccessToken);
 
   return useQuery({
-    queryKey: ["repos", space],
+    queryKey: ["repos", space?.spaceName ?? ""],
     queryFn: () => {
       if (!user || !space) {
         return [];
       }
 
-      return space === user.name ? api.getUserRepos() : api.getOrgRepos(space);
+      return api.getSpaceRepos(space);
     },
   });
 };

--- a/src/@hooks/useSpaceQuery.tsx
+++ b/src/@hooks/useSpaceQuery.tsx
@@ -11,7 +11,7 @@ export function useSpaceQuery() {
     .setUserId(user?.id);
 
   return useQuery({
-    queryKey: ["orgs"],
+    queryKey: ["spaces"],
     queryFn: () => {
       if (!user) {
         return [];

--- a/src/@hooks/useSpaceQuery.tsx
+++ b/src/@hooks/useSpaceQuery.tsx
@@ -17,18 +17,7 @@ export function useSpaceQuery() {
         return [];
       }
 
-      return api.getOrgs();
-    },
-    select: orgs => {
-      if (!user) {
-        return [];
-      }
-
-      return orgs.concat({
-        spaceName: user.name,
-        spaceUrl: user.githubUri,
-        spaceImage: user.image ?? "",
-      });
+      return api.getSpaces();
     },
   });
 }

--- a/src/@types/api.ts
+++ b/src/@types/api.ts
@@ -7,6 +7,7 @@ export type Response<T> = {
 };
 
 export type Space = {
+  installId: number;
   spaceName: string;
   spaceUrl: string;
   spaceImage: string;

--- a/src/@utils/api.ts
+++ b/src/@utils/api.ts
@@ -53,18 +53,6 @@ class APIClient {
     return this;
   }
 
-  async getUserRepos(): Promise<Repo[]> {
-    try {
-      const { data } = await this.client().get<Response<Repo[]>>(
-        `/users/${this.userId}/repos`,
-      );
-
-      return data.result;
-    } catch (error) {
-      throw error;
-    }
-  }
-
   async getSpaces(): Promise<Space[]> {
     try {
       const { data } = await this.client().get<Response<Space[]>>(
@@ -81,18 +69,6 @@ class APIClient {
     try {
       const { data } = await this.client().get<Response<Repo[]>>(
         `/users/${this.userId}/spaces/${space.installId}/repos`,
-      );
-
-      return data.result;
-    } catch (error) {
-      throw error;
-    }
-  }
-
-  async getOrgRepos(space: string): Promise<Repo[]> {
-    try {
-      const { data } = await this.client().get<Response<Repo[]>>(
-        `/users/${this.userId}/orgs/${space}/repos`,
       );
 
       return data.result;

--- a/src/@utils/api.ts
+++ b/src/@utils/api.ts
@@ -65,10 +65,10 @@ class APIClient {
     }
   }
 
-  async getOrgs(): Promise<Space[]> {
+  async getSpaces(): Promise<Space[]> {
     try {
       const { data } = await this.client().get<Response<Space[]>>(
-        `/users/${this.userId}/orgs`,
+        `/users/${this.userId}/spaces`,
       );
 
       return data.result;

--- a/src/@utils/api.ts
+++ b/src/@utils/api.ts
@@ -77,6 +77,18 @@ class APIClient {
     }
   }
 
+  async getSpaceRepos(space: Space): Promise<Repo[]> {
+    try {
+      const { data } = await this.client().get<Response<Repo[]>>(
+        `/users/${this.userId}/spaces/${space.installId}/repos`,
+      );
+
+      return data.result;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async getOrgRepos(space: string): Promise<Repo[]> {
     try {
       const { data } = await this.client().get<Response<Repo[]>>(

--- a/src/BuildOptionSelect/index.tsx
+++ b/src/BuildOptionSelect/index.tsx
@@ -6,9 +6,10 @@ import {
   useBuildOptions,
   useSetBuildOptions,
   useSetProjectName,
-  useProjectMutation,
+  useCreateProjectMutation,
   usePresetBuildOptions,
   usePresetBuildOptionActions,
+  useSpaceQuery,
 } from "../@hooks";
 import * as css from "./index.css";
 
@@ -19,6 +20,7 @@ export function BuildOptionSelect() {
   const navigate = useNavigate();
   const params = useParams();
 
+  const { data: spaces } = useSpaceQuery();
   const {
     defaultProjectName,
     defaultBuildCommand,
@@ -31,7 +33,7 @@ export function BuildOptionSelect() {
   const { setRepoName, setSpace, setDefaultCommand } =
     usePresetBuildOptionActions();
 
-  const deploy = useProjectMutation({
+  const deploy = useCreateProjectMutation({
     onSuccess: () => {
       navigate(`./deploy`);
     },
@@ -47,11 +49,13 @@ export function BuildOptionSelect() {
 
   useEffect(() => {
     const { userName, repository } = params;
-    if (!repository || !userName || !!buildOptions.projectName) {
+    const space = spaces?.find(space => space.spaceName === userName);
+
+    if (!repository || !userName || !!buildOptions.projectName || !space) {
       return;
     }
 
-    setSpace(userName);
+    setSpace(space);
     setRepoName(repository);
   }, []);
 
@@ -145,7 +149,7 @@ export function BuildOptionSelect() {
 
           <div className={css.buildOption}>
             <p className={css.buildOptionTitle}>Environment Varables</p>
-            <EnvField onEnvAdded={setBuildOptions("envList")} />
+            <EnvField />
           </div>
         </div>
       </section>

--- a/src/Landing/index.tsx
+++ b/src/Landing/index.tsx
@@ -15,7 +15,7 @@ export function Landing() {
     };
   }, [tick]);
 
-  const githubLoginUrl = `//${Config.GITHUB_OAUTH_URI}?client_id=${Config.CLIENT_ID}&redirect_uri=${Config.REDIRECT_URI}&scope=${Config.API_SCOPE}`;
+  const githubLoginUrl = `//${Config.GITHUB_OAUTH_URI}?client_id=${Config.CLIENT_ID}&redirect_uri=${Config.REDIRECT_URI}`;
 
   return (
     <div className={css.container}>

--- a/src/RepositorySelect/index.tsx
+++ b/src/RepositorySelect/index.tsx
@@ -27,6 +27,20 @@ export function RepositorySelect() {
     navigate(`/new/${space}/${repo}`);
   };
 
+  const handleSpaceClick = (selectedSpace: string) => {
+    if (!spaces) {
+      return;
+    }
+
+    const space = spaces.find(({ spaceName }) => spaceName == selectedSpace);
+
+    if (!space) {
+      return;
+    }
+
+    setSpace(space);
+  };
+
   return (
     <div className={css.container}>
       <section className={css.titleSection}>
@@ -41,7 +55,7 @@ export function RepositorySelect() {
       <section className={css.repositorySection}>
         <div className={css.searchConsole}>
           <SelectBox
-            onSelectionChange={setSpace}
+            onSelectionChange={handleSpaceClick}
             options={spaces?.map(({ spaceName }) => spaceName) ?? []}
           />
           <div className={css.textFieldSection}>


### PR DESCRIPTION
## Task

- ♻️ refactor: migrate Github Oauth Apps to Github Apps

## Description

- 기존 Github Oauth Apps로 인증되던 방식을 Github Apps로 바꾸었습니다.
- 이후에 추가될 Repository Update 로직과 관련해 webhook을 만들어주고 관리하기 보다 Apps를 설치하는 방향이 관리하기 용이하여 결정하였습니다.
- 최초 로그인 시 Github Apps로 인증되도록 변경하였습니다.
- Project를 구성할 때 repository list에서, Github Apps가 설치된 space와 repository가 나타나도록 api 수정하였습니다.
- space 값은 space 객체 내의 문자열로 관리되었었는데, 객체 전체를 관리하도록 수정하였습니다. 객체 내의 installId 값을 가져오기 위함입니다.
- 불필요한 코드들 삭제하였습니다.

## Key Points

- [리뷰에 집중할 부분]

## Checklist - reusable and pure functions

- [ ] Is everything function needs specified as parameters?
- Is function reusable (cacheable) and pure? (If it's possible)
- No random values
- No current date/time
- No global state (DOM, files, db, etc)
- No mutation of parameters

## Anything to add

- [기타 논의 사항]
